### PR TITLE
adds hm-soknad-api-q1 to kafka acl

### DIFF
--- a/kafka/rapid-dev.yaml
+++ b/kafka/rapid-dev.yaml
@@ -23,6 +23,9 @@ spec:
       application: hm-soknad-api
       access: write   # read, write, readwrite
     - team: teamdigihot
+      application: hm-soknad-api-q1
+      access: write   # read, write, readwrite
+    - team: teamdigihot
       application: hm-ditt-nav
       access: read    # read, write, readwrite
     - team: teamdigihot


### PR DESCRIPTION
Not sure if there should be an entirely separate file for q1, but this seemed like the most straightforward way to get unstuck