### PR TITLE
Begrense ordrelinje-notifikasjoner i ditt nav

### DIFF
--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/client/SøknadForRiverClient.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/client/SøknadForRiverClient.kt
@@ -33,7 +33,7 @@ internal interface SøknadForRiverClient {
 
     suspend fun save(soknadData: SoknadData)
     suspend fun soknadFinnes(soknadsId: UUID): Boolean
-    suspend fun ordreWithinSameDay(soknadsId: UUID): Boolean
+    suspend fun ordreSisteDøgn(soknadsId: UUID): Boolean
     suspend fun hentFnrForSoknad(soknadsId: UUID): String
     suspend fun slettSøknad(soknadsId: UUID): Int
     suspend fun oppdaterStatus(soknadsId: UUID, status: Status): Int

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/river/NyOrdrelinje.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/river/NyOrdrelinje.kt
@@ -94,7 +94,7 @@ internal class NyOrdrelinje(
                             logger.info("Ordrelinje sendt: ${ordrelinjeData.søknadId}")
                             sikkerlogg.info("Ordrelinje på bruker: ${ordrelinjeData.søknadId}, fnr: ${ordrelinjeData.fnrBruker})")
                         } else {
-                            logger.info("Ordrelinje mottatt, men varsel til bruker er allerede sendt ut det siste døgnet.")
+                            logger.info("Ordrelinje mottatt, men varsel til bruker er allerede sendt ut det siste døgnet: $søknadId")
                         }
                     } catch (e: Exception) {
                         throw RuntimeException("Håndtering av event ${packet.eventId} feilet", e)

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/river/NyOrdrelinje.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/river/NyOrdrelinje.kt
@@ -84,7 +84,13 @@ internal class NyOrdrelinje(
                         save(ordrelinjeData)
 
                         // TODO: Kommenter inn linja under for sending til rapid etter at businesslogikk er på plass
-                        // forward(ordrelinjeData, context)
+                        if (!søknadForRiverClient.ordreWithinSameDay(soknadsId = søknadId)) {
+                            context.send(ordrelinjeData.fnrBruker, ordrelinjeData.toJson("hm-OrdrelinjeLagret"))
+                            Prometheus.ordrelinjeLagretOgSendtTilRapidCounter.inc()
+                            logger.info("Ordrelinje sendt: ${ordrelinjeData.søknadId}")
+                            sikkerlogg.info("Ordrelinje på bruker: ${ordrelinjeData.søknadId}, fnr: ${ordrelinjeData.fnrBruker})")
+                        } else {
+                        }
                     } catch (e: Exception) {
                         throw RuntimeException("Håndtering av event ${packet.eventId} feilet", e)
                     }

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/service/OrdrelinjeData.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/service/OrdrelinjeData.kt
@@ -3,7 +3,6 @@ package no.nav.hjelpemidler.soknad.mottak.service
 import com.fasterxml.jackson.databind.JsonNode
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageProblems
-import java.time.LocalDateTime
 import java.util.UUID
 
 internal data class OrdrelinjeData(
@@ -20,13 +19,10 @@ internal data class OrdrelinjeData(
 ) {
     internal fun toJson(eventName: String): String {
         return JsonMessage("{}", MessageProblems("")).also {
-            it["eventId"] = UUID.randomUUID().toString()
             it["eventName"] = eventName
-            it["opprettet"] = LocalDateTime.now()
+            it["eventId"] = UUID.randomUUID().toString()
+            it["søknadId"] = this.søknadId
             it["fnrBruker"] = this.fnrBruker
-            it["artikkelnr"] = this.artikkelnr
-            it["antall"] = this.antall
-            it["produktgruppe"] = this.produktgruppe
         }.toJson()
     }
 }


### PR DESCRIPTION
Ta i bruk endepunktet i db for å sjekke om en ordrelinje er opprettet for produktet de siste 24 timene. Hvis det er gjort, skal ingen beskjed sendes til ditt nav.