### PR TITLE
Ordrelinjer sjekk infotrygd om vedtakdato lik now

### DIFF
--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -1,5 +1,9 @@
 name: ktlint
-on: [push]
+# on: [push]
+on:
+  push:
+    branches:
+      - disabled-acbdcs
 
 jobs:
   code-style-violations:

--- a/.github/workflows/ktlint.yml
+++ b/.github/workflows/ktlint.yml
@@ -1,10 +1,5 @@
 name: ktlint
-# on: [push]
-on:
-  push:
-    branches:
-      - disabled-acbdcs
-
+on: [push]
 jobs:
   code-style-violations:
     name: Check coding style violations

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,9 +1,5 @@
 name: Vulnerabilities scanning of dependencies
-# on: [push]
-on:
-  push:
-    branches:
-      - disabled-acbdcs
+on: [push]
 jobs:
   security:
     runs-on: ubuntu-latest

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,5 +1,9 @@
 name: Vulnerabilities scanning of dependencies
-on: push
+# on: [push]
+on:
+  push:
+    branches:
+      - disabled-acbdcs
 jobs:
   security:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ordrelinjer-sjekk-infotrygd-om-vedtakdato-lik-now
 
 env:
   IMAGE: "docker.pkg.github.com/${{ github.repository }}/hm-soknadsbehandling:${{ github.sha }}"
@@ -53,7 +52,7 @@ jobs:
   deploy-prod:
     name: Deploy to Production
     needs: [build, deploy-dev]
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - jira667-digihot-oppslag
+      - ordrelinjer-sjekk-infotrygd-om-vedtakdato-lik-now
 
 env:
   IMAGE: "docker.pkg.github.com/${{ github.repository }}/hm-soknadsbehandling:${{ github.sha }}"
@@ -50,15 +50,15 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: nais/nais-dev.yaml,nais/alerts-dev.yaml
           
-  deploy-prod:
-    name: Deploy to Production
-    needs: [build, deploy-dev]
-    if: github.ref == 'refs/heads/main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: nais/deploy/actions/deploy@v1
-        env:
-          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-          CLUSTER: prod-gcp
-          RESOURCE: nais/nais-prod.yaml,nais/alerts-prod.yaml
+#  deploy-prod:
+#    name: Deploy to Production
+#    needs: [build, deploy-dev]
+#    if: github.ref == 'refs/heads/main'
+#    runs-on: ubuntu-latest
+#    steps:
+#      - uses: actions/checkout@v2
+#      - uses: nais/deploy/actions/deploy@v1
+#        env:
+#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+#          CLUSTER: prod-gcp
+#          RESOURCE: nais/nais-prod.yaml,nais/alerts-prod.yaml

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -53,7 +53,7 @@ jobs:
   deploy-prod:
     name: Deploy to Production
     needs: [build, deploy-dev]
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -50,15 +50,15 @@ jobs:
           CLUSTER: dev-gcp
           RESOURCE: nais/nais-dev.yaml,nais/alerts-dev.yaml
           
-#  deploy-prod:
-#    name: Deploy to Production
-#    needs: [build, deploy-dev]
-#    if: github.ref == 'refs/heads/main'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - uses: actions/checkout@v2
-#      - uses: nais/deploy/actions/deploy@v1
-#        env:
-#          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
-#          CLUSTER: prod-gcp
-#          RESOURCE: nais/nais-prod.yaml,nais/alerts-prod.yaml
+  deploy-prod:
+    name: Deploy to Production
+    needs: [build, deploy-dev]
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: nais/deploy/actions/deploy@v1
+        env:
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-gcp
+          RESOURCE: nais/nais-prod.yaml,nais/alerts-prod.yaml

--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -26,6 +26,8 @@ spec:
         - application: hm-soknadsbehandling-db
         - application: hm-grunndata-api
         - application: digihot-oppslag
+      external:
+        - host: hm-infotrygd-proxy.dev-fss-pub.nais.io
   azure:
     application:
       enabled: true

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -26,6 +26,8 @@ spec:
         - application: hm-soknadsbehandling-db
         - application: hm-grunndata-api
         - application: digihot-oppslag
+      external:
+        - host: hm-infotrygd-proxy.prod-fss-pub.nais.io
   azure:
     application:
       enabled: true

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/Application.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/Application.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.hjelpemidler.soknad.mottak.aad.AzureClient
+import no.nav.hjelpemidler.soknad.mottak.client.InfotrygdProxyClientImpl
 import no.nav.hjelpemidler.soknad.mottak.client.PdlClient
 import no.nav.hjelpemidler.soknad.mottak.client.SøknadForRiverClientImpl
 import no.nav.hjelpemidler.soknad.mottak.metrics.InfluxMetrics
@@ -45,9 +46,10 @@ fun main() {
         clientSecret = Configuration.azure.clientSecret
     )
 
-    val baseUrlSoknadsbehandlingDb = Configuration.soknadsbehandlingDb.baseUrl
     val søknadForRiverClient =
-        SøknadForRiverClientImpl(baseUrlSoknadsbehandlingDb, azureClient, Configuration.azure.dbApiScope)
+        SøknadForRiverClientImpl(Configuration.soknadsbehandlingDb.baseUrl, azureClient, Configuration.azure.dbApiScope)
+    val infotrygdProxyClient =
+        InfotrygdProxyClientImpl(Configuration.infotrygdProxy.baseUrl, azureClient, Configuration.azure.infotrygdProxyScope)
     val pdlClient = PdlClient(azureClient, Configuration.pdl.baseUrl, Configuration.pdl.apiScope)
     val influxMetrics = InfluxMetrics(pdlClient)
 
@@ -63,7 +65,7 @@ fun main() {
             JournalpostSink(this, søknadForRiverClient)
             OppgaveSink(this, søknadForRiverClient)
             DigitalSøknadEndeligJournalført(this, søknadForRiverClient)
-            NyInfotrygdOrdrelinje(this, søknadForRiverClient)
+            NyInfotrygdOrdrelinje(this, søknadForRiverClient, infotrygdProxyClient)
             NyHotsakOrdrelinje(this, søknadForRiverClient)
             VedtaksresultatFraInfotrygd(this, søknadForRiverClient)
             PapirSøknadEndeligJournalført(this, søknadForRiverClient, influxMetrics)

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/Configuration.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/Configuration.kt
@@ -25,6 +25,7 @@ private val localProperties = ConfigurationMap(
         "AZURE_APP_CLIENT_ID" to "123",
         "AZURE_APP_CLIENT_SECRET" to "dummy",
         "DBAPI_SCOPE" to "123",
+        "INFOTRYGD_PROXY_SCOPE" to "123",
         "INFLUX_HOST" to "http://localhost",
         "INFLUX_PORT" to "1234",
         "INFLUX_DATABASE_NAME" to "defaultdb",
@@ -32,6 +33,7 @@ private val localProperties = ConfigurationMap(
         "INFLUX_PASSWORD" to "password",
         "SOKNADSBEHANDLING_DB_BASEURL" to "http://localhost:8083/api",
         "SOKNADSBEHANDLING_DB_CLIENT_ID" to "local:hm-soknadsbehandling-db",
+        "INFOTRYGD_PROXY_BASEURL" to "http://localhost:8083/infotrygdproxy",
         "PDL_API_URL" to "http://localhost:9098/pdl",
         "PDL_API_SCOPE" to "api://dev-gcp.pdl.pdl-api/.default",
         "SLACK_HOOK" to "http://dummy",
@@ -49,7 +51,9 @@ private val devProperties = ConfigurationMap(
         "KAFKA_TOPIC" to "teamdigihot.hm-soknadsbehandling-v1",
         "AZURE_TENANT_BASEURL" to "https://login.microsoftonline.com",
         "DBAPI_SCOPE" to "api://dev-gcp.teamdigihot.hm-soknadsbehandling-db/.default",
+        "INFOTRYGD_PROXY_SCOPE" to "api://dev-fss.teamdigihot.hm-infotrygd-proxy/.default",
         "SOKNADSBEHANDLING_DB_CLIENT_ID" to "dev-gcp:teamdigihot:hm-soknadsbehandling-db",
+        "INFOTRYGD_PROXY_BASEURL" to "https://hm-infotrygd-proxy.dev-fss-pub.nais.io",
         "PDL_API_URL" to "https://pdl-api.dev-fss-pub.nais.io/graphql",
         "PDL_API_SCOPE" to "api://dev-fss.pdl.pdl-api/.default",
         "POST_DOKUMENTBESKRIVELSE_TO_SLACK" to "false",
@@ -65,7 +69,9 @@ private val prodProperties = ConfigurationMap(
         "KAFKA_TOPIC" to "teamdigihot.hm-soknadsbehandling-v1",
         "AZURE_TENANT_BASEURL" to "https://login.microsoftonline.com",
         "DBAPI_SCOPE" to "api://prod-gcp.teamdigihot.hm-soknadsbehandling-db/.default",
+        "INFOTRYGD_PROXY_SCOPE" to "api://prod-fss.teamdigihot.hm-infotrygd-proxy/.default",
         "SOKNADSBEHANDLING_DB_CLIENT_ID" to "prod-gcp:teamdigihot:hm-soknadsbehandling-db",
+        "INFOTRYGD_PROXY_BASEURL" to "https://hm-infotrygd-proxy.prod-fss-pub.nais.io",
         "PDL_API_URL" to "https://pdl-api.prod-fss-pub.nais.io/graphql",
         "PDL_API_SCOPE" to "api://prod-fss.pdl.pdl-api/.default",
         "POST_DOKUMENTBESKRIVELSE_TO_SLACK" to "true",
@@ -87,6 +93,7 @@ internal object Configuration {
     }
 
     val soknadsbehandlingDb: SoknadsbehandlingDb = SoknadsbehandlingDb()
+    val infotrygdProxy: InfotrygdProxy = InfotrygdProxy()
     val hmdb: Hmdb = Hmdb()
     val slack: Slack = Slack()
     val azure: Azure = Azure()
@@ -118,7 +125,8 @@ internal object Configuration {
         val tenantId: String = config[Key("AZURE_APP_TENANT_ID", stringType)],
         val clientId: String = config[Key("AZURE_APP_CLIENT_ID", stringType)],
         val clientSecret: String = config[Key("AZURE_APP_CLIENT_SECRET", stringType)],
-        val dbApiScope: String = config[Key("DBAPI_SCOPE", stringType)]
+        val dbApiScope: String = config[Key("DBAPI_SCOPE", stringType)],
+        val infotrygdProxyScope: String = config[Key("INFOTRYGD_PROXY_SCOPE", stringType)],
     )
 
     data class InfluxDb(
@@ -136,6 +144,10 @@ internal object Configuration {
 
     data class SoknadsbehandlingDb(
         val baseUrl: String = config[Key("SOKNADSBEHANDLING_DB_BASEURL", stringType)],
+    )
+
+    data class InfotrygdProxy(
+        val baseUrl: String = config[Key("INFOTRYGD_PROXY_BASEURL", stringType)],
     )
 
     data class Hmdb(

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/client/Dto.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/client/Dto.kt
@@ -1,6 +1,7 @@
 package no.nav.hjelpemidler.soknad.mottak.service
 
 import com.fasterxml.jackson.databind.JsonNode
+import java.time.LocalDate
 import java.util.Date
 import java.util.UUID
 
@@ -28,4 +29,9 @@ class UtgåttSøknad(
     val søknadId: UUID? = null,
     val status: Status? = null,
     val fnrBruker: String? = null
+)
+
+data class SøknadIdFraVedtaksresultat(
+    val søknadId: UUID,
+    val vedtaksDato: LocalDate?,
 )

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/client/InfotrygdProxyClient.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/client/InfotrygdProxyClient.kt
@@ -1,0 +1,74 @@
+package no.nav.hjelpemidler.soknad.mottak.client
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.kittinunf.fuel.core.Request
+import com.github.kittinunf.fuel.core.ResponseDeserializable
+import com.github.kittinunf.fuel.core.extensions.jsonBody
+import com.github.kittinunf.fuel.coroutines.awaitObject
+import com.github.kittinunf.fuel.httpGet
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import mu.KotlinLogging
+import no.nav.hjelpemidler.soknad.mottak.JacksonMapper
+import no.nav.hjelpemidler.soknad.mottak.aad.AzureClient
+import java.time.LocalDate
+import java.util.UUID
+
+private val logger = KotlinLogging.logger {}
+
+internal interface InfotrygdProxyClient {
+    suspend fun harVedtakFor(fnr: String, saksblokk: String, saksnr: String, vedtaksDato: LocalDate): Boolean
+}
+
+internal class InfotrygdProxyClientImpl(
+    private val baseUrl: String,
+    private val azureClient: AzureClient,
+    private val accesstokenScope: String,
+) : InfotrygdProxyClient {
+
+    override suspend fun harVedtakFor(fnr: String, saksblokk: String, saksnr: String, vedtaksDato: LocalDate): Boolean {
+        data class Request(
+            val fnr: String,
+            val saksblokk: String,
+            val saksnr: String,
+            val vedtaksDato: LocalDate,
+        )
+        data class Response(
+            val resultat: Boolean,
+        )
+        return withContext(Dispatchers.IO) {
+            kotlin.runCatching {
+                "$baseUrl/har-vedtak-for".httpGet()
+                    .headers()
+                    .jsonBody(
+                        JacksonMapper.objectMapper.writeValueAsString(
+                            Request(
+                                fnr,
+                                saksblokk,
+                                saksnr,
+                                vedtaksDato,
+                            )
+                        )
+                    )
+                    .awaitObject(
+                        object : ResponseDeserializable<Response> {
+                            override fun deserialize(content: String): Response {
+                                return JacksonMapper.objectMapper.readValue(content)
+                            }
+                        }
+                    ).resultat
+            }.onFailure {
+                logger.error { it.message }
+            }.getOrDefault(false)
+        }
+    }
+
+    private fun Request.headers() = this.header(
+        mapOf(
+            "Content-Type" to "application/json",
+            "Accept" to "application/json",
+            "Authorization" to "Bearer ${azureClient.getToken(accesstokenScope).accessToken}",
+            "X-Correlation-ID" to UUID.randomUUID().toString()
+        )
+    )
+}

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/client/InfotrygdProxyClient.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/client/InfotrygdProxyClient.kt
@@ -5,7 +5,7 @@ import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.ResponseDeserializable
 import com.github.kittinunf.fuel.core.extensions.jsonBody
 import com.github.kittinunf.fuel.coroutines.awaitObject
-import com.github.kittinunf.fuel.httpGet
+import com.github.kittinunf.fuel.httpPost
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import mu.KotlinLogging
@@ -38,7 +38,7 @@ internal class InfotrygdProxyClientImpl(
         )
         return withContext(Dispatchers.IO) {
             kotlin.runCatching {
-                "$baseUrl/har-vedtak-for".httpGet()
+                "$baseUrl/har-vedtak-for".httpPost()
                     .headers()
                     .jsonBody(
                         JacksonMapper.objectMapper.writeValueAsString(

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/river/NyInfotrygdOrdrelinje.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/river/NyInfotrygdOrdrelinje.kt
@@ -74,6 +74,9 @@ internal class NyInfotrygdOrdrelinje(
                     if (it.count() == 1) {
                         it.first()
                     } else {
+                        if (it.count() > 1) {
+                            sikkerlogg.warn("Fant flere søknader med matchende fnr+saksblokkOgSaksnr+vedtaksdato (saksblokkOgSaksnr=${packet.saksblokkOgSaksnr}, vedtaksdato=${packet.vedtaksdato}, antallTreff=${it.count()}, ider: [$it])")
+                        }
                         null
                     }
                 }
@@ -94,11 +97,12 @@ internal class NyInfotrygdOrdrelinje(
                         if (it.count() == 1) {
                             it.first()
                         } else {
+                            if (it.count() > 1) {
+                                logger.info("Fant flere søknader på bruker som ikke har fått vedtaksdato enda, kan derfor ikke matche til korrekt av dem uten mer informasjon (antall=${it.count()})")
+                            }
                             null
                         }
                     }
-
-                    logger.info("DEBUG: TEST: søknadId=$søknadId (søknadIder: $søknadIder)")
 
                     if (søknadId != null) {
                         // Check if we have a decision that is just not synced yet
@@ -108,8 +112,6 @@ internal class NyInfotrygdOrdrelinje(
                             packet.saksblokkOgSaksnr.takeLast(2),
                             packet.vedtaksdato
                         )
-
-                        logger.info("DEBUG: TEST: harVedtakInfotrygd=$harVedtakInfotrygd")
 
                         if (harVedtakInfotrygd) {
                             logger.info("Ordrelinje med eventId ${packet.eventId} matchet mot søknad indirekte med sjekk av infotrygd-databasen (vedtaksdato=${packet.vedtaksdato}, saksblokkOgSaksnr=${packet.saksblokkOgSaksnr})")
@@ -124,8 +126,6 @@ internal class NyInfotrygdOrdrelinje(
                         logger.warn("Ordrelinje med eventId ${packet.eventId} kan ikkje matchast mot ein søknadId (vedtaksdato=${packet.vedtaksdato}, saksblokkOgSaksnr=${packet.saksblokkOgSaksnr})")
                         return@runBlocking
                     }
-                } else {
-                    logger.info("DEBUG: TEST: SøknadId != null")
                 }
 
                 val ordrelinjeData = OrdrelinjeData(

--- a/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/river/NyInfotrygdOrdrelinje.kt
+++ b/src/main/kotlin/no/nav/hjelpemidler/soknad/mottak/river/NyInfotrygdOrdrelinje.kt
@@ -7,6 +7,7 @@ import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helse.rapids_rivers.asLocalDate
+import no.nav.hjelpemidler.soknad.mottak.client.InfotrygdProxyClient
 import no.nav.hjelpemidler.soknad.mottak.client.SøknadForRiverClient
 import no.nav.hjelpemidler.soknad.mottak.metrics.Prometheus
 import no.nav.hjelpemidler.soknad.mottak.service.OrdrelinjeData
@@ -18,7 +19,8 @@ private val sikkerlogg = KotlinLogging.logger("tjenestekall")
 
 internal class NyInfotrygdOrdrelinje(
     rapidsConnection: RapidsConnection,
-    private val søknadForRiverClient: SøknadForRiverClient
+    private val søknadForRiverClient: SøknadForRiverClient,
+    private val infotrygdProxyClient: InfotrygdProxyClient,
 ) : PacketListenerWithOnError {
 
     init {
@@ -70,6 +72,10 @@ internal class NyInfotrygdOrdrelinje(
                 )
                 if (søknadId == null) {
                     logger.warn { "Ordrelinje med eventId ${packet.eventId} kan ikkje matchast mot ein søknadId (vedtaksdato=${packet.vedtaksdato}, saksblokkOgSaksnr=${packet.saksblokkOgSaksnr})" }
+
+                    val harVedtakInfotrygd = infotrygdProxyClient.harVedtakFor(packet.fnrBruker, packet.saksblokkOgSaksnr.take(1), packet.saksblokkOgSaksnr.takeLast(2), packet.vedtaksdato)
+                    logger.info("DEBUG: TEST: harVedtakInfotrygd=$harVedtakInfotrygd")
+
                     return@runBlocking
                 }
 

--- a/src/test/kotlin/no/nav/hjelpemidler/soknad/mottak/metrics/kommune/KommuneServiceTest.kt
+++ b/src/test/kotlin/no/nav/hjelpemidler/soknad/mottak/metrics/kommune/KommuneServiceTest.kt
@@ -1,7 +1,6 @@
 package no.nav.hjelpemidler.soknad.mottak.metrics.kommune
 
 import com.github.kittinunf.fuel.core.FuelError
-import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 


### PR DESCRIPTION
Vi får ofte ordrelinjer samme dag som vedtaket gjøres, noe som i Infotrygd flyten betyr at vi ikke kan knytte disse til en gitt søknad (vi får ikke knytningen før neste dag). Dermed kaster vi disse. Dette gjelder rundt 10% av alle ordrelinjer.